### PR TITLE
feat: connect apply link update and route/accessibility hardening

### DIFF
--- a/src/app/activity/[category]/page.tsx
+++ b/src/app/activity/[category]/page.tsx
@@ -76,7 +76,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
         <div className="relative aspect-1440/587 w-full">
           <Image src="https://image.bcsdlab.com/bcsd_activity_page.png" alt="Event Image" fill sizes="100vw" priority />
           <div className="absolute inset-0 flex items-end">
-            <div className="font-inter relative bottom-10 left-50 z-10 m-4 rounded-md text-[40px] font-semibold text-white">
+            <div className="font-inter relative bottom-10 left-50 z-10 m-4 rounded-md text-[40px] leading-[120%] font-semibold text-white">
               <div>BCSD에서는</div>
               <div>이런 활동을 하고 있어요.</div>
             </div>

--- a/src/app/activity/[category]/page.tsx
+++ b/src/app/activity/[category]/page.tsx
@@ -1,12 +1,16 @@
 import { Suspense } from 'react';
 import Image from 'next/image';
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import type { ActivityCategory, ActivityList } from '@/types/activity';
 import { getActivity } from '@/static/activity';
 import ActivityContent from '../components/ActivityContent';
 import GlobalNavigationBar from '@/components/GlobalNavigationBar';
 
 const getYears = (groups: ActivityList[]) => groups.map((g) => g.year).sort((a, b) => Number(b) - Number(a));
+const ACTIVITY_CATEGORIES = ['event', 'game', 'koin'] as const satisfies readonly ActivityCategory[];
+const activityCategorySet = new Set<string>(ACTIVITY_CATEGORIES);
+const isActivityCategory = (value: string): value is ActivityCategory => activityCategorySet.has(value);
 
 const categoryInfo: Record<ActivityCategory, { title: string; description: string }> = {
   event: {
@@ -23,13 +27,22 @@ const categoryInfo: Record<ActivityCategory, { title: string; description: strin
   },
 };
 
+export const dynamicParams = false;
+
 export function generateStaticParams() {
-  return [{ category: 'event' }, { category: 'game' }, { category: 'koin' }] satisfies { category: ActivityCategory }[];
+  return ACTIVITY_CATEGORIES.map((category) => ({ category }));
 }
 
 export async function generateMetadata({ params }: ActivityPageProps): Promise<Metadata> {
   const { category } = await params;
-  const info = categoryInfo[category];
+  const info = isActivityCategory(category) ? categoryInfo[category] : null;
+
+  if (!info) {
+    return {
+      title: '활동',
+      description: 'BCSD 활동 페이지',
+    };
+  }
 
   return {
     title: `${info.title} 활동`,
@@ -55,16 +68,16 @@ export async function generateMetadata({ params }: ActivityPageProps): Promise<M
   };
 }
 
-interface ActivityPage {
-  category: ActivityCategory;
-}
-
 interface ActivityPageProps {
-  params: Promise<ActivityPage>;
+  params: Promise<{ category: string }>;
 }
 
 export default async function ActivityPage({ params }: ActivityPageProps) {
   const { category } = await params;
+
+  if (!isActivityCategory(category)) {
+    notFound();
+  }
 
   const activityGroups = await getActivity(category);
   const years = getYears(activityGroups);

--- a/src/app/activity/[category]/page.tsx
+++ b/src/app/activity/[category]/page.tsx
@@ -8,9 +8,6 @@ import ActivityContent from '../components/ActivityContent';
 import GlobalNavigationBar from '@/components/GlobalNavigationBar';
 
 const getYears = (groups: ActivityList[]) => groups.map((g) => g.year).sort((a, b) => Number(b) - Number(a));
-const ACTIVITY_CATEGORIES = ['event', 'game', 'koin'] as const satisfies readonly ActivityCategory[];
-const activityCategorySet = new Set<string>(ACTIVITY_CATEGORIES);
-const isActivityCategory = (value: string): value is ActivityCategory => activityCategorySet.has(value);
 
 const categoryInfo: Record<ActivityCategory, { title: string; description: string }> = {
   event: {
@@ -27,10 +24,13 @@ const categoryInfo: Record<ActivityCategory, { title: string; description: strin
   },
 };
 
+const isActivityCategory = (value: string): value is ActivityCategory =>
+  Object.prototype.hasOwnProperty.call(categoryInfo, value);
+
 export const dynamicParams = false;
 
 export function generateStaticParams() {
-  return ACTIVITY_CATEGORIES.map((category) => ({ category }));
+  return (Object.keys(categoryInfo) as ActivityCategory[]).map((category) => ({ category }));
 }
 
 export async function generateMetadata({ params }: ActivityPageProps): Promise<Metadata> {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -112,7 +112,7 @@
     display: block;
   }
   body {
-    line-height: 1;
+    line-height: 1.5;
   }
   ol,
   ul {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -73,6 +73,8 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  const currentYear = new Date().getFullYear();
+
   return (
     <html lang="ko">
       <body>
@@ -80,7 +82,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
         <footer className="flex justify-between bg-[#555] px-13.5">
           <div className="flex flex-col justify-center py-10">
             <FooterCharacter />
-            <p className="text-xs font-normal text-[#C4C4C4]">© 2025 BCSD. ALL RIGHTS RESERVED.</p>
+            <p className="text-xs font-normal text-[#C4C4C4]">© {currentYear} BCSD. ALL RIGHTS RESERVED.</p>
           </div>
           <div className="flex items-center justify-center gap-4">
             <Link href={URLS.SOCIAL.FACEBOOK}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link';
 import Image from 'next/image';
 import MainImage from '@/assets/svg/main/main-image.svg';
 import MainIconPipe from '@/assets/svg/main/main-icon-pipe.svg';
@@ -8,7 +7,7 @@ import MainIconPartner from '@/assets/svg/main/main-icon-partner.svg';
 import QnADropdown from '@/components/QnADropdown';
 import MentorSlider from '@/components/MentorSlider';
 import GlobalNavigationBar from '@/components/GlobalNavigationBar';
-import { URLS } from '@/constants/urls';
+import ApplyButton from '@/components/ApplyButton';
 
 export default function Home() {
   return (
@@ -30,9 +29,7 @@ export default function Home() {
                 <br />
                 BCSD와 함께 성장하세요.
               </p>
-              <Link href={URLS.APPLICATION_FORM} className="mt-6 inline-block rounded-[10px] bg-[#C360F3] px-5 py-3.25">
-                <p className="text-white">지원하기</p>
-              </Link>
+              <ApplyButton className="mt-6 rounded-[10px] bg-[#C360F3] px-5 py-3.25 text-white" />
             </div>
           </div>
         </div>
@@ -84,12 +81,7 @@ export default function Home() {
             <div className="mt-16">
               <p className="text-center text-[34px] font-medium">또 하나의 행성 할 사람?</p>
               <div className="text-center">
-                <Link
-                  href="https://docs.google.com/forms/d/e/1FAIpQLSfMP9HZIE4TzVpoWX_o3nnUB_tAthRSIsJTfKw72F4mftA62w/viewform?edit2=2_ABaOnueiLzcPk7-tUYyUJ6fU1Zxy5Kpyr2uACwdIkIHWchOsPBhTOHJlF74Oo37Skw"
-                  className="inline-block rounded-[10px] bg-[#D365FD] p-2.5"
-                >
-                  <p className="text-[17px] text-[#FFF]">저요!</p>
-                </Link>
+                <ApplyButton className="mt-6 rounded-[10px] bg-[#D365FD] p-2.5 text-[17px] text-[#FFF]" label="저요!" />
               </div>
             </div>
             <MainCharacter className="absolute bottom-0 left-0" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,7 +24,7 @@ export default function Home() {
           />
           <div className="absolute inset-0">
             <div className="font-inter absolute top-75 left-30 m-4 -translate-y-1/2 text-white min-[1440px]:top-75 min-[1440px]:left-35 min-[1440px]:translate-y-0">
-              <p className="text-[40px] font-semibold">
+              <p className="text-[40px] leading-[120%] font-semibold">
                 각자의 궤도를 그리며
                 <br />
                 BCSD와 함께 성장하세요.
@@ -39,7 +39,7 @@ export default function Home() {
           <div className="space-y-20">
             <div className="flex justify-between px-30 pt-30">
               <div>
-                <p className="text-[34px] font-medium text-neutral-100">열린 공간 BCSD</p>
+                <p className="text-[34px] leading-[120%] font-medium text-neutral-100">열린 공간 BCSD</p>
                 <p className="mt-3.25">
                   마치 은하계가 외부의 다른 천체들과 상호작용하듯,
                   <br /> BCSD는 구성원들 간의 교류뿐만 아니라 외부의 다양한
@@ -50,7 +50,7 @@ export default function Home() {
             </div>
             <div className="relative flex h-150 items-center justify-center bg-[linear-gradient(180deg,rgba(255,255,255,0.00)_-9.38%,#FEF2FF_67.06%,rgba(255,255,255,0.00)_90.62%)]">
               <div className="space-y-4 text-center">
-                <p className="text-[34px] font-medium text-neutral-100">함께 성장하는 BCSD</p>
+                <p className="text-[34px] leading-[120%] font-medium text-neutral-100">함께 성장하는 BCSD</p>
                 <p>
                   행성들은 고유한 궤도를 따라 움직이며 하나의 체계를 유지하듯이,
                   <br /> BCSD 내에서 각자가 자신의 목표를 향해 나아가면서도,
@@ -79,7 +79,7 @@ export default function Home() {
               </p>
             </div>
             <div className="mt-16">
-              <p className="text-center text-[34px] font-medium">또 하나의 행성 할 사람?</p>
+              <p className="text-center text-[34px] leading-[120%] font-medium">또 하나의 행성 할 사람?</p>
               <div className="text-center">
                 <ApplyButton className="mt-6 rounded-[10px] bg-[#D365FD] p-2.5 text-[17px] text-[#FFF]" label="저요!" />
               </div>

--- a/src/app/recruit/components/TrackSection.tsx
+++ b/src/app/recruit/components/TrackSection.tsx
@@ -1,6 +1,5 @@
 import { type TrackItem, TRACKS } from '@/static/recruit/trackDescription';
-import Link from 'next/link';
-import { URLS } from '@/constants/urls';
+import ApplyButton from '@/components/ApplyButton';
 
 function TrackCard({ title, description, Icon }: TrackItem) {
   return (
@@ -26,12 +25,7 @@ export default function TrackSection() {
           <div>함께 프로젝트를 진행하며 자신의 능력을 향상시키고</div>
           <div>싶은 분들의 많은 지원바랍니다.</div>
         </div>
-        <Link
-          className="rounded-[10px] bg-[#D365FD] p-2.5 text-[17px] font-medium text-white"
-          href={URLS.APPLICATION_FORM}
-        >
-          지원하기
-        </Link>
+        <ApplyButton className="rounded-[10px] bg-[#D365FD] p-2.5 text-[17px] font-medium text-white" />
       </div>
 
       <div className="mt-15 grid grid-cols-3 gap-6">

--- a/src/app/recruit/components/TrackSection.tsx
+++ b/src/app/recruit/components/TrackSection.tsx
@@ -1,5 +1,6 @@
 import { type TrackItem, TRACKS } from '@/static/recruit/trackDescription';
 import ApplyButton from '@/components/ApplyButton';
+import { RECRUIT_TERM } from '@/constants/recruit';
 
 function TrackCard({ title, description, Icon }: TrackItem) {
   return (
@@ -16,7 +17,7 @@ export default function TrackSection() {
     <div className="mt-6">
       <div className="text-center">
         <div className="inline-block rounded-lg bg-[#f5dbff] px-3 py-1.5 text-center text-[15px] font-medium text-[#b611f5]">
-          2025년 하반기
+          {RECRUIT_TERM}
         </div>
         <div className="title mt-3">
           <span className="font-bold">BCSD와 함께 할 준비</span>가 되었나요?

--- a/src/app/recruit/page.tsx
+++ b/src/app/recruit/page.tsx
@@ -4,11 +4,12 @@ import BeginnerTimeLine from './components/Timeline';
 import BenefitCards from './components/BenefitCards';
 import TrackSection from './components/TrackSection';
 import GlobalNavigationBar from '@/components/GlobalNavigationBar';
+import { RECRUIT_TERM } from '@/constants/recruit';
 
 export const metadata: Metadata = {
   title: '모집 안내',
   description:
-    'BCSD 2025년 하반기 신입 부원 모집. Frontend, Backend, Android, iOS, Design, Game, Data Analyst, PM, Security 트랙에서 함께 성장할 멤버를 찾습니다.',
+    `BCSD ${RECRUIT_TERM} 신입 부원 모집. Frontend, Backend, Android, iOS, Design, Game, Data Analyst, PM, Security 트랙에서 함께 성장할 멤버를 찾습니다.`,
   keywords: [
     'BCSD 모집',
     '동아리 모집',

--- a/src/app/recruit/page.tsx
+++ b/src/app/recruit/page.tsx
@@ -52,11 +52,11 @@ export default function Recruit() {
           />
 
           <div className="absolute inset-0 flex items-center justify-center text-center">
-            <div className="absolute z-0 translate-x-0.5 translate-y-2.25 bg-linear-to-t from-[#666] to-[#999] bg-clip-text text-[40px] font-semibold whitespace-nowrap text-transparent opacity-80">
+            <div className="absolute z-0 translate-x-0.5 translate-y-2.25 bg-linear-to-t from-[#666] to-[#999] bg-clip-text text-[40px] leading-[120%] font-semibold whitespace-nowrap text-transparent opacity-80">
               <div>각자의 궤도를 그리며</div>
               <div>BCSD와 함께 성장하세요.</div>
             </div>
-            <div className="font-inter relative z-10 text-[40px] font-semibold whitespace-nowrap text-white">
+            <div className="font-inter relative z-10 text-[40px] leading-[120%] font-semibold whitespace-nowrap text-white">
               <div>각자의 궤도를 그리며</div>
               <div>BCSD와 함께 성장하세요.</div>
             </div>

--- a/src/app/track/[track]/page.tsx
+++ b/src/app/track/[track]/page.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/image';
 import type { Metadata } from 'next';
-import { notFound } from 'next/navigation';
 import type { TrackName } from '@/types/curriculum';
 import TrackTabs from '@/app/track/components/TrackTabs';
 import StudyCards from '@/app/track/components/StudyCard';
@@ -9,9 +8,6 @@ import TrackMember from '@/app/track/components/TrackMember';
 import GlobalNavigationBar from '@/components/GlobalNavigationBar';
 import ScrollUpButton from '@/components/ScrollUpButton';
 import { tracks } from '@/app/track/components/TrackTabs';
-
-const trackSlugSet = new Set<string>(tracks.map(({ slug }) => slug));
-const isTrackName = (value: string): value is TrackName => trackSlugSet.has(value);
 
 const trackDescriptions: Record<TrackName, string> = {
   frontend: '사용자 인터페이스를 구축하고 웹 애플리케이션을 개발합니다.',
@@ -33,14 +29,6 @@ export function generateStaticParams() {
 
 export async function generateMetadata({ params }: { params: TrackPageParams }): Promise<Metadata> {
   const { track } = await params;
-
-  if (!isTrackName(track)) {
-    return {
-      title: '트랙',
-      description: 'BCSD 트랙 소개 페이지',
-    };
-  }
-
   const trackInfo = tracks.find(({ slug }) => slug === track);
   const trackName = trackInfo?.label || track;
   const description = trackDescriptions[track];
@@ -69,14 +57,10 @@ export async function generateMetadata({ params }: { params: TrackPageParams }):
   };
 }
 
-type TrackPageParams = Promise<{ track: string }>;
+type TrackPageParams = Promise<{ track: TrackName }>;
 
 export default async function TrackPage({ params }: { params: TrackPageParams }) {
   const { track } = await params;
-
-  if (!isTrackName(track)) {
-    notFound();
-  }
 
   return (
     <div className="hide-scrollbar w-full overflow-x-auto">

--- a/src/app/track/[track]/page.tsx
+++ b/src/app/track/[track]/page.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
 import type { TrackName } from '@/types/curriculum';
 import TrackTabs from '@/app/track/components/TrackTabs';
 import StudyCards from '@/app/track/components/StudyCard';
@@ -8,6 +9,9 @@ import TrackMember from '@/app/track/components/TrackMember';
 import GlobalNavigationBar from '@/components/GlobalNavigationBar';
 import ScrollUpButton from '@/components/ScrollUpButton';
 import { tracks } from '@/app/track/components/TrackTabs';
+
+const trackSlugSet = new Set<string>(tracks.map(({ slug }) => slug));
+const isTrackName = (value: string): value is TrackName => trackSlugSet.has(value);
 
 const trackDescriptions: Record<TrackName, string> = {
   frontend: '사용자 인터페이스를 구축하고 웹 애플리케이션을 개발합니다.',
@@ -21,12 +25,22 @@ const trackDescriptions: Record<TrackName, string> = {
   security: '시스템과 네트워크의 보안을 강화하고 취약점을 분석합니다.',
 };
 
+export const dynamicParams = false;
+
 export function generateStaticParams() {
   return tracks.map(({ slug }) => ({ track: slug }));
 }
 
 export async function generateMetadata({ params }: { params: TrackPageParams }): Promise<Metadata> {
   const { track } = await params;
+
+  if (!isTrackName(track)) {
+    return {
+      title: '트랙',
+      description: 'BCSD 트랙 소개 페이지',
+    };
+  }
+
   const trackInfo = tracks.find(({ slug }) => slug === track);
   const trackName = trackInfo?.label || track;
   const description = trackDescriptions[track];
@@ -55,13 +69,14 @@ export async function generateMetadata({ params }: { params: TrackPageParams }):
   };
 }
 
-interface TrackPage {
-  track: TrackName;
-}
-type TrackPageParams = Promise<TrackPage>;
+type TrackPageParams = Promise<{ track: string }>;
 
 export default async function TrackPage({ params }: { params: TrackPageParams }) {
   const { track } = await params;
+
+  if (!isTrackName(track)) {
+    notFound();
+  }
 
   return (
     <div className="hide-scrollbar w-full overflow-x-auto">

--- a/src/app/track/components/Curriculum.tsx
+++ b/src/app/track/components/Curriculum.tsx
@@ -19,16 +19,16 @@ function WeekBox({ week }: WeekBoxProps) {
       </div>
 
       <div className="min-w-0 flex-1 border-t border-[#E7E7E7]">
-        {week.items.map((row, index) => (
+        {week.items.map((row) => (
           <div
-            key={index}
+            key={`${row.index}-${row.title}`}
             className="grid grid-cols-[2.75rem_16.75rem_1fr] items-start gap-x-7 border-b border-[#E7E7E7] py-2.75"
           >
             <div className="text-right text-[17px] leading-[150%] text-neutral-200 tabular-nums">{row.index}</div>
             <div className="text-xl leading-[130%] font-semibold whitespace-pre-line">{row.title}</div>
-            <div className="min-w-0 text-[17px] leading-[150%] break-words text-neutral-200">
-              {row.detail?.map((detailRow, index) => (
-                <div key={index}>{detailRow}</div>
+            <div className="min-w-0 text-[17px] leading-[150%] wrap-break-word text-neutral-200">
+              {row.detail?.map((detailRow) => (
+                <div key={detailRow}>{detailRow}</div>
               ))}
             </div>
           </div>

--- a/src/app/track/components/Curriculum.tsx
+++ b/src/app/track/components/Curriculum.tsx
@@ -13,27 +13,26 @@ interface WeekBoxProps {
 
 function WeekBox({ week }: WeekBoxProps) {
   return (
-    <div className="flex w-300 justify-between">
-      <div className="text-xl font-semibold">{formatWeekLabel(week.week)}</div>
+    <div className="flex w-300 items-start gap-10">
+      <div className="w-24 shrink-0 pt-2.75 text-xl font-semibold whitespace-nowrap tabular-nums">
+        {formatWeekLabel(week.week)}
+      </div>
 
-      <div className="border-t">
-        <div className="flex gap-25">
-          <div className="flex w-full flex-col">
-            {week.items.map((row, index) => (
-              <div key={index} className="flex gap-25 border-b border-b-[#E7E7E7] py-2.75">
-                <div className="flex gap-7">
-                  <div>{row.index}</div>
-                  <div className="w-67 text-xl font-semibold whitespace-pre-line">{row.title}</div>
-                </div>
-                <div className="w-122">
-                  {row.detail?.map((detailRow, index) => (
-                    <div key={index}>{detailRow}</div>
-                  ))}
-                </div>
-              </div>
-            ))}
+      <div className="min-w-0 flex-1 border-t border-[#E7E7E7]">
+        {week.items.map((row, index) => (
+          <div
+            key={index}
+            className="grid grid-cols-[2.75rem_16.75rem_1fr] items-start gap-x-7 border-b border-[#E7E7E7] py-2.75"
+          >
+            <div className="text-right text-[17px] leading-[150%] text-neutral-200 tabular-nums">{row.index}</div>
+            <div className="text-xl leading-[130%] font-semibold whitespace-pre-line">{row.title}</div>
+            <div className="min-w-0 text-[17px] leading-[150%] break-words text-neutral-200">
+              {row.detail?.map((detailRow, index) => (
+                <div key={index}>{detailRow}</div>
+              ))}
+            </div>
           </div>
-        </div>
+        ))}
       </div>
     </div>
   );

--- a/src/app/track/components/Curriculum.tsx
+++ b/src/app/track/components/Curriculum.tsx
@@ -27,8 +27,8 @@ function WeekBox({ week }: WeekBoxProps) {
             <div className="text-right text-[17px] leading-[150%] text-neutral-200 tabular-nums">{row.index}</div>
             <div className="text-xl leading-[130%] font-semibold whitespace-pre-line">{row.title}</div>
             <div className="min-w-0 text-[17px] leading-[150%] wrap-break-word text-neutral-200">
-              {row.detail?.map((detailRow) => (
-                <div key={detailRow}>{detailRow}</div>
+              {row.detail?.map((detailRow, index) => (
+                <div key={index}>{detailRow}</div>
               ))}
             </div>
           </div>

--- a/src/app/track/components/MemberCarousel.tsx
+++ b/src/app/track/components/MemberCarousel.tsx
@@ -31,8 +31,8 @@ export default function MemberCarousel({ members }: { members: Member[] }) {
 
   return (
     <Swiper modules={[Navigation, A11y]} navigation slidesPerView="auto" loop={canLoop} className="member-swiper">
-      {members.map((member, index) => (
-        <SwiperSlide key={index} className="w-74.5!">
+      {members.map((member) => (
+        <SwiperSlide key={`${member.name}-${member.role}-${member.image}`} className="w-74.5!">
           <MemberCard {...member} />
         </SwiperSlide>
       ))}

--- a/src/app/track/components/StudyCard.tsx
+++ b/src/app/track/components/StudyCard.tsx
@@ -25,8 +25,8 @@ export default async function StudyCards({ track }: StudyCardsProps) {
       <div className="title">WHAT WE STUDY</div>
       <div className="mt-15 flex gap-4.5">
         <div className="flex gap-4.5">
-          {cards.map((card, index) => (
-            <StudyCard key={index} {...card} />
+          {cards.map((card) => (
+            <StudyCard key={card.title} {...card} />
           ))}
         </div>
       </div>

--- a/src/components/ApplyButton.tsx
+++ b/src/components/ApplyButton.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import Link from 'next/link';
-import { useRef, useEffect } from 'react';
+import { useEffect, useId, useRef } from 'react';
 import useBooleanState from '@/hooks/useBooleanState';
 import { URLS } from '@/constants/urls';
+import useEscapeKeyDown from '@/hooks/useEscapeKeyDown';
 
 interface ApplyButtonProps {
   className?: string;
@@ -12,29 +13,50 @@ interface ApplyButtonProps {
 
 export default function ApplyButton({ className, label = '지원하기' }: ApplyButtonProps) {
   const [isOpen, open, close] = useBooleanState(false);
+  const menuId = useId();
   const ref = useRef<HTMLDivElement>(null);
 
+  useEscapeKeyDown(() => {
+    close();
+  });
+
   useEffect(() => {
-    const handleOutsideClick = (e: MouseEvent) => {
+    const handleOutsideClick = (e: MouseEvent | TouchEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) {
         close();
       }
     };
     document.addEventListener('mousedown', handleOutsideClick);
-    return () => document.removeEventListener('mousedown', handleOutsideClick);
+    document.addEventListener('touchstart', handleOutsideClick);
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick);
+      document.removeEventListener('touchstart', handleOutsideClick);
+    };
   }, [close]);
 
   return (
     <div ref={ref} className="relative inline-block">
-      <button onClick={isOpen ? close : open} className={className}>
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-controls={menuId}
+        aria-expanded={isOpen}
+        onClick={isOpen ? close : open}
+        className={className}
+      >
         {label}
       </button>
       {isOpen && (
-        <div className="absolute top-full left-1/2 z-50 mt-2 w-40 -translate-x-1/2 overflow-hidden rounded-xl bg-white shadow-lg">
+        <div
+          id={menuId}
+          role="menu"
+          className="absolute top-full left-1/2 z-50 mt-2 w-40 -translate-x-1/2 overflow-hidden rounded-xl bg-white shadow-lg"
+        >
           <Link
             href={URLS.STORE.PLAY_STORE}
             target="_blank"
             rel="noopener noreferrer"
+            role="menuitem"
             className="flex items-center gap-2 px-4 py-2.5 text-sm text-neutral-700 hover:bg-gray-50"
             onClick={close}
           >
@@ -44,6 +66,7 @@ export default function ApplyButton({ className, label = '지원하기' }: Apply
             href={URLS.STORE.APP_STORE}
             target="_blank"
             rel="noopener noreferrer"
+            role="menuitem"
             className="flex items-center gap-2 px-4 py-2.5 text-sm text-neutral-700 hover:bg-gray-50"
             onClick={close}
           >

--- a/src/components/ApplyButton.tsx
+++ b/src/components/ApplyButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useId, useRef } from 'react';
+import { useCallback, useEffect, useId, useRef } from 'react';
 import useBooleanState from '@/hooks/useBooleanState';
 import { URLS } from '@/constants/urls';
 import useEscapeKeyDown from '@/hooks/useEscapeKeyDown';
@@ -15,28 +15,91 @@ export default function ApplyButton({ className, label = '지원하기' }: Apply
   const [isOpen, open, close] = useBooleanState(false);
   const menuId = useId();
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const menuItemRefs = useRef<Array<HTMLAnchorElement | null>>([]);
 
-  useEscapeKeyDown(() => {
+  const focusMenuItem = (index: number) => {
+    menuItemRefs.current[index]?.focus();
+  };
+
+  const closeMenu = useCallback(() => {
     close();
+    triggerRef.current?.focus();
+  }, [close]);
+
+  useEscapeKeyDown((e) => {
+    if (!isOpen) return;
+    e.stopPropagation();
+    closeMenu();
   });
 
   useEffect(() => {
+    if (!isOpen) return;
+
     const handleOutsideClick = (e: MouseEvent | TouchEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) {
-        close();
+        closeMenu();
       }
     };
+
     document.addEventListener('mousedown', handleOutsideClick);
     document.addEventListener('touchstart', handleOutsideClick);
+
     return () => {
       document.removeEventListener('mousedown', handleOutsideClick);
       document.removeEventListener('touchstart', handleOutsideClick);
     };
-  }, [close]);
+  }, [isOpen, closeMenu]);
+
+  useEffect(() => {
+    if (!isOpen || !menuRef.current) return;
+    focusMenuItem(0);
+  }, [isOpen]);
+
+  const handleMenuKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const items = menuItemRefs.current.filter((item): item is HTMLAnchorElement => item !== null);
+    if (items.length === 0) return;
+
+    const currentIndex = items.findIndex((item) => item === document.activeElement);
+    const hasFocusInside = currentIndex >= 0;
+
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      closeMenu();
+      return;
+    }
+
+    if (e.key === 'Home') {
+      e.preventDefault();
+      items[0]?.focus();
+      return;
+    }
+
+    if (e.key === 'End') {
+      e.preventDefault();
+      items[items.length - 1]?.focus();
+      return;
+    }
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      const nextIndex = hasFocusInside ? (currentIndex + 1) % items.length : 0;
+      items[nextIndex]?.focus();
+      return;
+    }
+
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const prevIndex = hasFocusInside ? (currentIndex - 1 + items.length) % items.length : items.length - 1;
+      items[prevIndex]?.focus();
+    }
+  };
 
   return (
     <div ref={ref} className="relative inline-block">
       <button
+        ref={triggerRef}
         type="button"
         aria-haspopup="menu"
         aria-controls={menuId}
@@ -48,11 +111,16 @@ export default function ApplyButton({ className, label = '지원하기' }: Apply
       </button>
       {isOpen && (
         <div
+          ref={menuRef}
           id={menuId}
           role="menu"
+          onKeyDown={handleMenuKeyDown}
           className="absolute top-full left-1/2 z-50 mt-2 w-40 -translate-x-1/2 overflow-hidden rounded-xl bg-white shadow-lg"
         >
           <Link
+            ref={(el) => {
+              menuItemRefs.current[0] = el;
+            }}
             href={URLS.STORE.PLAY_STORE}
             target="_blank"
             rel="noopener noreferrer"
@@ -63,6 +131,9 @@ export default function ApplyButton({ className, label = '지원하기' }: Apply
             Play Store
           </Link>
           <Link
+            ref={(el) => {
+              menuItemRefs.current[1] = el;
+            }}
             href={URLS.STORE.APP_STORE}
             target="_blank"
             rel="noopener noreferrer"

--- a/src/components/ApplyButton.tsx
+++ b/src/components/ApplyButton.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import Link from 'next/link';
+import { useRef, useEffect } from 'react';
+import useBooleanState from '@/hooks/useBooleanState';
+import { URLS } from '@/constants/urls';
+
+interface ApplyButtonProps {
+  className?: string;
+  label?: string;
+}
+
+export default function ApplyButton({ className, label = '지원하기' }: ApplyButtonProps) {
+  const [isOpen, open, close] = useBooleanState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleOutsideClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        close();
+      }
+    };
+    document.addEventListener('mousedown', handleOutsideClick);
+    return () => document.removeEventListener('mousedown', handleOutsideClick);
+  }, [close]);
+
+  return (
+    <div ref={ref} className="relative inline-block">
+      <button onClick={isOpen ? close : open} className={className}>
+        {label}
+      </button>
+      {isOpen && (
+        <div className="absolute top-full left-1/2 z-50 mt-2 w-40 -translate-x-1/2 overflow-hidden rounded-xl bg-white shadow-lg">
+          <Link
+            href={URLS.STORE.PLAY_STORE}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 px-4 py-2.5 text-sm text-neutral-700 hover:bg-gray-50"
+            onClick={close}
+          >
+            Play Store
+          </Link>
+          <Link
+            href={URLS.STORE.APP_STORE}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2 px-4 py-2.5 text-sm text-neutral-700 hover:bg-gray-50"
+            onClick={close}
+          >
+            App Store
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/MentorSlider.tsx
+++ b/src/components/MentorSlider.tsx
@@ -59,7 +59,12 @@ export default function MentorSlider() {
         ))}
       </Swiper>
       <div className="mt-4 flex w-full justify-end px-16">
-        <button className="cursor-pointer" onClick={handleTogglePlay}>
+        <button
+          type="button"
+          aria-label={isPlaying ? '멘토 슬라이더 자동재생 일시정지' : '멘토 슬라이더 자동재생 시작'}
+          className="cursor-pointer"
+          onClick={handleTogglePlay}
+        >
           {isPlaying ? <StopButtonIcon /> : <PlayButtonIcon />}
         </button>
       </div>

--- a/src/components/QnADropdown.tsx
+++ b/src/components/QnADropdown.tsx
@@ -31,7 +31,7 @@ export default function QnADropdown() {
   return (
     <div className="mt-32.5 flex w-full justify-center gap-8 p-10">
       <div className="w-1/3">
-        <h2 className="text-[34px] font-medium">자주 물어보는 질문</h2>
+        <h2 className="text-[34px] leading-[120%] font-medium">자주 물어보는 질문</h2>
         <p className="text-[17px] font-normal">더 궁금한 사항이 있다면 아래 메일로 문의바랍니다.</p>
         <Link href="mailto:bcsdlab@gmail.com" className="hover:underline">
           bcsdlab@gmail.com
@@ -47,7 +47,7 @@ export default function QnADropdown() {
                 onClick={() => toggle(index)}
                 className="flex items-center justify-between bg-[#F9F9F9] p-4.25 text-left"
               >
-                <span className="text-[20px] font-medium">{qna.question}</span>
+                <span className="text-[20px] leading-[130%] font-medium">{qna.question}</span>
                 <span className={`transition-transform duration-300 ${isDropDownOpen ? 'rotate-180' : ''}`}>
                   <DownArrow />
                 </span>

--- a/src/components/QnADropdown.tsx
+++ b/src/components/QnADropdown.tsx
@@ -41,19 +41,29 @@ export default function QnADropdown() {
       <div className="w-1/3 space-y-4">
         {QnAData.map((qna, index) => {
           const isDropDownOpen = isOpen[index];
+          const triggerId = `qna-trigger-${qna.id}`;
+          const contentId = `qna-content-${qna.id}`;
+
           return (
             <div key={qna.id} className="overflow-hidden rounded-lg border border-gray-200">
-              <div
+              <button
+                type="button"
+                id={triggerId}
+                aria-expanded={isDropDownOpen}
+                aria-controls={contentId}
                 onClick={() => toggle(index)}
-                className="flex items-center justify-between bg-[#F9F9F9] p-4.25 text-left"
+                className="flex w-full items-center justify-between bg-[#F9F9F9] p-4.25 text-left"
               >
                 <span className="text-[20px] leading-[130%] font-medium">{qna.question}</span>
                 <span className={`transition-transform duration-300 ${isDropDownOpen ? 'rotate-180' : ''}`}>
                   <DownArrow />
                 </span>
-              </div>
+              </button>
 
               <div
+                id={contentId}
+                role="region"
+                aria-labelledby={triggerId}
                 className={`bg-[#F9F9F9] transition-[max-height] duration-300 ease-out`}
                 style={{ maxHeight: isDropDownOpen ? heights[index] : 0 }}
               >

--- a/src/components/ScrollUpButton.tsx
+++ b/src/components/ScrollUpButton.tsx
@@ -26,7 +26,7 @@ export default function ScrollUpButton() {
   if (!isVisible) return null;
 
   return (
-    <button onClick={scrollToTop} className="fixed right-30 bottom-20 z-10">
+    <button type="button" aria-label="맨 위로 이동" onClick={scrollToTop} className="fixed right-30 bottom-20 z-10">
       <UpButton />
     </button>
   );

--- a/src/components/Selector.tsx
+++ b/src/components/Selector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef } from 'react';
+import { useId, useRef } from 'react';
 import useHandleOutside from '@/hooks/useOutsideClick';
 import ArrowDown from '@/assets/svg/polygon-icon.svg';
 import useEscapeKeyDown from '@/hooks/useEscapeKeyDown';
@@ -19,6 +19,7 @@ interface SelectorProps {
 
 export default function Selector({ options, value, onSelect }: SelectorProps) {
   const [isOpen, , closeMenu, triggerOpen] = useBooleanState(false);
+  const listboxId = useId();
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   const backgroundRef = useRef<HTMLDivElement | null>(null);
@@ -50,6 +51,9 @@ export default function Selector({ options, value, onSelect }: SelectorProps) {
         <button
           type="button"
           onClick={triggerOpen}
+          aria-haspopup="listbox"
+          aria-controls={listboxId}
+          aria-expanded={isOpen}
           className="relative flex w-full items-center justify-center rounded-full bg-[#f4f4f4] py-2"
         >
           <div className="mx-auto text-[17px]">{showLabel}</div>
@@ -61,18 +65,23 @@ export default function Selector({ options, value, onSelect }: SelectorProps) {
         </button>
 
         {isOpen && (
-          <div role="listbox" className="absolute mt-2 w-full rounded-[21px] bg-[#f4f4f4] px-7 shadow">
-            {options.map((option) => (
-              <div
-                role="option"
-                aria-selected={option.value === value}
-                key={option.value}
-                onClick={handleOptionSelect(option.value)}
-                className="cursor-pointer border-b border-b-[#dbdbdb] py-2 text-center last:border-b-0"
-              >
-                {option.label}
-              </div>
-            ))}
+          <div id={listboxId} role="listbox" className="absolute mt-2 w-full rounded-[21px] bg-[#f4f4f4] px-7 shadow">
+            {options.map((option) => {
+              const isSelected = option.value === value;
+
+              return (
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  key={option.value}
+                  onClick={handleOptionSelect(option.value)}
+                  className="w-full cursor-pointer border-b border-b-[#dbdbdb] py-2 text-center last:border-b-0"
+                >
+                  {option.label}
+                </button>
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/components/Selector.tsx
+++ b/src/components/Selector.tsx
@@ -28,6 +28,13 @@ export default function Selector({ options, value, onSelect }: SelectorProps) {
     onSelect(value);
     closeMenu();
   };
+  const handleOptionKeyDown = (optionValue: string) => (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onSelect(optionValue);
+      closeMenu();
+    }
+  };
 
   const selectedOption = options.find((option) => option.value === value);
   const showLabel = selectedOption ? selectedOption.label : 'Select an option';
@@ -70,16 +77,17 @@ export default function Selector({ options, value, onSelect }: SelectorProps) {
               const isSelected = option.value === value;
 
               return (
-                <button
-                  type="button"
+                <div
                   role="option"
+                  tabIndex={0}
                   aria-selected={isSelected}
                   key={option.value}
                   onClick={handleOptionSelect(option.value)}
+                  onKeyDown={handleOptionKeyDown(option.value)}
                   className="w-full cursor-pointer border-b border-b-[#dbdbdb] py-2 text-center last:border-b-0"
                 >
                   {option.label}
-                </button>
+                </div>
               );
             })}
           </div>

--- a/src/constants/recruit.ts
+++ b/src/constants/recruit.ts
@@ -1,0 +1,1 @@
+export const RECRUIT_TERM = '2026년 상반기';

--- a/src/constants/urls.ts
+++ b/src/constants/urls.ts
@@ -1,7 +1,9 @@
 export const URLS = {
-  /** BCSD 지원 폼 URL */
-  APPLICATION_FORM:
-    'https://docs.google.com/forms/d/e/1FAIpQLSfMP9HZIE4TzVpoWX_o3nnUB_tAthRSIsJTfKw72F4mftA62w/viewform?edit2=2_ABaOnueiLzcPk7-tUYyUJ6fU1Zxy5Kpyr2uACwdIkIHWchOsPBhTOHJlF74Oo37Skw',
+  /** 코넥트 앱 스토어 URL */
+  STORE: {
+    PLAY_STORE: 'https://play.google.com/store/apps/details?id=com.bcsdlab.konect',
+    APP_STORE: 'https://apps.apple.com/kr/app/konect-%EB%8F%99%EC%95%84%EB%A6%AC/id6756885059',
+  },
 
   /** 소셜 미디어 URL */
   SOCIAL: {

--- a/src/styles/font.css
+++ b/src/styles/font.css
@@ -1,7 +1,7 @@
 @import 'tailwindcss';
 
 @font-face {
-  font-family: 'Pretendard';
+  font-family: Pretendard;
   src: url('../assets/fonts/Pretendard-Regular.woff2') format('woff2');
   font-weight: 400;
   font-style: normal;
@@ -9,7 +9,7 @@
 }
 
 @font-face {
-  font-family: 'Pretendard';
+  font-family: Pretendard;
   src: url('../assets/fonts/Pretendard-Bold.woff2') format('woff2');
   font-weight: 700;
   font-style: normal;

--- a/src/styles/font.css
+++ b/src/styles/font.css
@@ -1,5 +1,21 @@
 @import 'tailwindcss';
 
+@font-face {
+  font-family: 'Pretendard';
+  src: url('../assets/fonts/Pretendard-Regular.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Pretendard';
+  src: url('../assets/fonts/Pretendard-Bold.woff2') format('woff2');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
 @theme {
   --font-inter: 'Inter', sans-serif;
   --font-pretendard: 'Pretendard', sans-serif;


### PR DESCRIPTION
## Summary
- include 2 local `develop` commits
  - `fd34d5a` feat: 구글 폼 대신 코넥트로 연결되게 변경
  - `8574e83` refactor: 줄바꿈 수치 변경
- add current fixes for routing stability, accessibility, and maintenance improvements

## Changes
- harden dynamic routes to return 404 on invalid params
  - `activity/[category]`, `track/[track]`
  - add `dynamicParams = false` and runtime guards with `notFound()`
- improve accessibility
  - FAQ dropdown trigger from non-semantic container to button
  - selector list options to proper buttons with aria attributes
  - add aria labels and explicit button types for control buttons
  - apply button menu semantics and Escape/outside-close support
- remove year hardcoding in footer by using current year
- centralize recruit term string via constant
- add `@font-face` loading for Pretendard local font files
- replace unstable index keys in mapped lists with stable keys

## Validation
- `pnpm lint` passed
- `pnpm exec tsc --noEmit` passed
- `pnpm build` could not be re-validated due existing `.next/lock` process in local environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App store links added for submissions via a new Apply button.
  * Recruitment term made dynamic; copyright year updates automatically.

* **Improvements**
  * Enhanced accessibility: ARIA attributes, explicit button semantics, and keyboard navigation across interactive components.
  * Improved error handling: invalid category/track pages now return proper 404 behavior.
  * Typography and fonts refined for better spacing and readability.
  * List rendering robustness improved with more reliable keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->